### PR TITLE
fix update `obtainTwoScore` arguments in CLI function

### DIFF
--- a/h1d/__main__.py
+++ b/h1d/__main__.py
@@ -166,7 +166,7 @@ def CLI():
             exit(0)
 
         ms = multiScore(args.matrix,args.resolution,args.chromosome,control_path=args.controlmatrix)
-        score,path,control_path = ms.obtainTwoScore(args.type,parameter=args.parameter,datatype=args.datatype,gt=args.gt,juicer=args.juicertool)
+        score,path,control_path = ms.obtainTwoScore(args.type,parameter=args.parameter,datatype=args.datatype,gt=args.gt)
         print("Saving...")
         score.to_csv(args.outname + ".bedGraph", sep="\t", header=False, index=False)
 


### PR DESCRIPTION
it removes unexpected keyword argument `juicer` from `obtainTwoScore`

```
File "/home/miss-leriem.zellagui/miniconda3/envs/h1d_env/lib/python3.10/site-packages/h1d/__main__.py", line 169, in func_two
    score,path,control_path = ms.obtainTwoScore(args.type,parameter=args.parameter,datatype=args.datatype,gt=args.gt,juicer=args.juicertool)
TypeError: multiScore.obtainTwoScore() got an unexpected keyword argument 'juicer'
```